### PR TITLE
Removed the defined struct TrajStateVar and made use of the class SteamTrajVar

### DIFF
--- a/samples/SimpleBAandTrajPrior.cpp
+++ b/samples/SimpleBAandTrajPrior.cpp
@@ -264,10 +264,5 @@ int main(int argc, char** argv) {
   // Optimize
   solver.optimize();
 
-  // Setup Trajectory
-  for (unsigned int i = 0; i < traj_states_ic.size(); i++) {
-    steam::se3::SteamTrajVar&state = traj_states_ic.at(i);
-   // std::cout << i << ": \n " << state.velocity->getValue() << "\n";
-  }
   return 0;
 }


### PR DESCRIPTION
In SimpleBAandTrajPrior.cpp, removed the defined struct TrajStateVar and made use of the class steam::se3::SteamTrajVar
- Currently, TransformStateVar::Ptr objects(which gets fed into the problem as state variables) are stored in a list
- TODO: can we directly obtain TransformStateVar::Ptr from TransformEvaluator::Ptr?
