### PR TITLE
Adding cost term function, preventing steam from using bad covariances

### DIFF
--- a/include/steam/evaluator/samples/StereoCameraErrorEval.hpp
+++ b/include/steam/evaluator/samples/StereoCameraErrorEval.hpp
@@ -75,7 +75,23 @@ class LandmarkNoiseEvaluator : public NoiseEvaluator<4> {
   virtual Eigen::Matrix<double,4,4> evaluate();
 
  private:
- 
+  template <int N>
+  bool positiveDefinite(const Eigen::Matrix<double,N,N> &matrix) {
+  
+    // Initialize an eigen value solver
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double,N,N>> 
+       eigsolver(matrix, Eigen::EigenvaluesOnly);
+
+    // Check the minimum eigen value
+    auto positive_definite = eigsolver.eigenvalues().minCoeff() > 0;
+    if (!positive_definite) {
+      std::cout << "Covariance \n" << matrix << "\n must be positive definite. "
+                << "Min. eigenvalue : " << eigsolver.eigenvalues().minCoeff();
+    }
+    
+    return positive_definite;
+  }
+
   /// \brief The stereo camera intrinsics.
   CameraIntrinsics::ConstPtr intrinsics_;
 

--- a/include/steam/problem/ParallelizedCostTermCollection.hpp
+++ b/include/steam/problem/ParallelizedCostTermCollection.hpp
@@ -71,6 +71,7 @@ class ParallelizedCostTermCollection : public CostTermBase
                                      BlockSparseMatrix* approximateHessian,
                                      BlockVector* gradientVector) const;
 
+  virtual std::vector<double> costs() const;
  private:
 
   //////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/steam/trajectory/SteamTrajInterface.hpp
+++ b/include/steam/trajectory/SteamTrajInterface.hpp
@@ -80,6 +80,9 @@ class SteamTrajInterface
   void getActiveStateVariables(
       std::map<unsigned int, steam::StateVariableBase::Ptr>* outStates) const;
 
+  double getPosePriorCost();
+  double getVelocityPriorCost();
+
  private:
 
   //////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/problem/ParallelizedCostTermCollection.cpp
+++ b/src/problem/ParallelizedCostTermCollection.cpp
@@ -32,6 +32,13 @@ void ParallelizedCostTermCollection::add(const CostTermBase::ConstPtr& costTerm)
   costTerms_.push_back(costTerm);
 }
 
+std::vector<double> ParallelizedCostTermCollection::costs() const {
+  std::vector<double> costs;
+  for (auto &cost_term : costTerms_) {
+    costs.push_back(cost_term->cost());
+  }
+  return costs;
+}
 //////////////////////////////////////////////////////////////////////////////////////////////
 /// \brief Compute the cost from the collection of cost terms
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -48,7 +55,12 @@ double ParallelizedCostTermCollection::cost() const {
   {
     #pragma omp for reduction(+:cost)
     for(unsigned int i = 0; i < costTerms_.size(); i++) {
-      cost += costTerms_.at(i)->cost();
+      double cost_i = costTerms_.at(i)->cost();
+      if(isnan(cost_i) == false) {
+        cost += costTerms_.at(i)->cost();
+      } else {
+        std::cout << "nan cost term!";
+      }
     }
   }
   return cost;

--- a/src/trajectory/SteamTrajInterface.cpp
+++ b/src/trajectory/SteamTrajInterface.cpp
@@ -27,6 +27,21 @@ SteamTrajInterface::SteamTrajInterface(bool allowExtrapolation) :
   Qc_inv_(Eigen::Matrix<double,6,6>::Identity()), allowExtrapolation_(allowExtrapolation) {
 }
 
+double SteamTrajInterface::getPosePriorCost() {
+  if(posePriorFactor_ != nullptr) {
+    return posePriorFactor_->cost();
+  } else {
+    return 0.0;
+  }
+}
+
+double SteamTrajInterface::getVelocityPriorCost() {
+  if(velocityPriorFactor_ != nullptr) {
+    return velocityPriorFactor_->cost();
+  } else {
+    return 0.0;
+  }
+}
 //////////////////////////////////////////////////////////////////////////////////////////////
 /// \brief Constructor
 //////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is code that @mpaton wrote to (a) pull costs out of steam for analysis, and (b) prevent cost terms that are not positive definite from being used.