### PR TITLE
Re-introduce Dynamic Noise Models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 log/
 install/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,6 @@ add_compile_options(-march=native -O3 -Wall -pedantic -Wno-unused-function)
 
 # define number of threads to be used by OpenMP in steam
 add_definitions(-DSTEAM_DEFAULT_NUM_OPENMP_THREADS=4)
-add_compile_options(-g -Og)
-
 
 ## cmake flow (default)
 if (NOT USE_AMENT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ add_compile_options(-march=native -O3 -Wall -pedantic -Wno-unused-function)
 
 # define number of threads to be used by OpenMP in steam
 add_definitions(-DSTEAM_DEFAULT_NUM_OPENMP_THREADS=4)
-add_compile_options(-g)
+add_compile_options(-g -Og)
 
 
 ## cmake flow (default)

--- a/include/steam.hpp
+++ b/include/steam.hpp
@@ -27,6 +27,7 @@
 #include "steam/problem/cost_term/weighted_least_sq_cost_term.hpp"
 #include "steam/problem/loss_func/loss_funcs.hpp"
 #include "steam/problem/noise_model/static_noise_model.hpp"
+#include "steam/problem/noise_model/dynamic_noise_model.hpp"
 #include "steam/problem/optimization_problem.hpp"
 #include "steam/problem/sliding_window_filter.hpp"
 

--- a/include/steam/evaluable/stereo/stereo_error_evaluator.hpp
+++ b/include/steam/evaluable/stereo/stereo_error_evaluator.hpp
@@ -1,7 +1,9 @@
 #pragma once
+#include <iostream>
 
 #include "steam/evaluable/evaluable.hpp"
 #include "steam/evaluable/stereo/compose_landmark_evaluator.hpp"
+#include "steam/evaluable/se3/se3_state_var.hpp"
 
 namespace steam {
 namespace stereo {
@@ -22,6 +24,10 @@ struct CameraIntrinsics {
   /** \brief Focal center offset in the v-coordinate (vertical) */
   double cv;
 };
+
+
+Eigen::Vector4d cameraModel(const CameraIntrinsics::ConstPtr& intrinsics, const Eigen::Vector4d& point);
+Eigen::Matrix4d cameraModelJacobian(const CameraIntrinsics::ConstPtr& intrinsics, const Eigen::Vector4d& point);
 
 /** \brief Stereo camera error function evaluator */
 class StereoErrorEvaluator : public Evaluable<Eigen::Vector4d> {
@@ -51,10 +57,6 @@ class StereoErrorEvaluator : public Evaluable<Eigen::Vector4d> {
                 Jacobians& jacs) const override;
 
  private:
-  Eigen::Vector4d cameraModel(const Eigen::Vector4d& point) const;
-  Eigen::Matrix4d cameraModelJacobian(const Eigen::Vector4d& point) const;
-
- private:
   /** \brief Measurement coordinates extracted from images (ul vl ur vr) */
   const Eigen::Vector4d meas_;
 
@@ -67,5 +69,76 @@ class StereoErrorEvaluator : public Evaluable<Eigen::Vector4d> {
    */
   const ComposeLandmarkEvaluator::ConstPtr eval_;
 };
+
+/** \brief Evaluates the noise of an uncertain map landmark, which has been reprojected into the
+        a query coordinate frame using a steam transform evaluator. */
+class LandmarkNoiseEvaluator : public Evaluable<Eigen::Matrix<double,4,4>> {
+ public:
+
+  /// \brief Constructor
+  /// \param The landmark mean, in the query frame.
+  /// \param The landmark covariance, in the query frame.
+  /// \param The noise on the landmark measurement.
+  /// \param The stereo camera intrinsics.
+  /// \param The steam transform evaluator that takes points from the landmark frame
+  ///        into the query frame.
+  LandmarkNoiseEvaluator(const Eigen::Vector4d& landmark_mean,
+                         const Eigen::Matrix3d& landmark_cov,
+                         const Eigen::Matrix4d& meas_noise,
+                         const CameraIntrinsics::ConstPtr& intrinsics,
+                         const se3::SE3StateVar::ConstPtr& T_query_map);
+
+  /// \brief Default destructor
+  ~LandmarkNoiseEvaluator()=default;
+  
+  /// \brief Evaluates the reprojection covariance 
+  /// @return the 4x4 covariance of the landmark reprojected into the query stereo
+  ///         camera frame.
+  virtual Eigen::Matrix<double,4,4> value();
+
+ private:
+  template <int N>
+  bool positiveDefinite(const Eigen::Matrix<double,N,N> &matrix) {
+  
+    // Initialize an eigen value solver
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double,N,N>> 
+       eigsolver(matrix, Eigen::EigenvaluesOnly);
+
+    // Check the minimum eigen value
+    auto positive_definite = eigsolver.eigenvalues().minCoeff() > 0;
+    if (!positive_definite) {
+      std::cout << "Covariance \n" << matrix << "\n must be positive definite. "
+                << "Min. eigenvalue : " << eigsolver.eigenvalues().minCoeff();
+    }
+    
+    return positive_definite;
+  }
+
+  /// \brief The stereo camera intrinsics.
+  CameraIntrinsics::ConstPtr intrinsics_;
+
+  /// \brief The landmark covariance.
+  Eigen::Matrix4d meas_noise_;
+
+  /// \brief the landmark mean.
+  Eigen::Vector4d mean_;
+
+  /// \brief The steam transform evaluator that takes points from the landmark frame
+  ///        into the query frame.
+  se3::SE3StateVar::ConstPtr T_query_map_;
+
+  /// \brief The 3x3 landmark covariance (phi) dialated into a 3x3 matrix.
+  /// @details dialated_phi_ = D*phi*D^T, where D is a 4x3 dialation matrix.
+  Eigen::Matrix4d dialated_phi_;
+
+  /// \brief The stereo camarea jacobian, evaluated at landmark mean, j.
+  Eigen::Matrix4d camera_jacobian_j_;
+
+  // \brief the last computed covariance
+  Eigen::Matrix<double,4,4> last_computed_cov_;
+};
+
+
+
 }  // end namespace stereo
 }  // namespace steam

--- a/include/steam/evaluable/stereo/stereo_error_evaluator.hpp
+++ b/include/steam/evaluable/stereo/stereo_error_evaluator.hpp
@@ -3,7 +3,6 @@
 
 #include "steam/evaluable/evaluable.hpp"
 #include "steam/evaluable/stereo/compose_landmark_evaluator.hpp"
-#include "steam/evaluable/se3/se3_state_var.hpp"
 
 namespace steam {
 namespace stereo {

--- a/include/steam/evaluable/stereo/stereo_error_evaluator.hpp
+++ b/include/steam/evaluable/stereo/stereo_error_evaluator.hpp
@@ -71,8 +71,8 @@ class StereoErrorEvaluator : public Evaluable<Eigen::Vector4d> {
 };
 
 /** \brief Evaluates the noise of an uncertain map landmark, which has been reprojected into the
-        a query coordinate frame using a steam transform evaluator. */
-class LandmarkNoiseEvaluator : public Evaluable<Eigen::Matrix<double,4,4>> {
+        a query coordinate frame into the camera pixels. */
+class LandmarkNoiseEvaluator : public Evaluable<Eigen::Matrix<double, 4, 4>> {
  public:
 
   /// \brief Constructor
@@ -88,7 +88,6 @@ class LandmarkNoiseEvaluator : public Evaluable<Eigen::Matrix<double,4,4>> {
                          const CameraIntrinsics::ConstPtr& intrinsics,
                          const typename Evaluable<lgmath::se3::Transformation>::ConstPtr& T_query_map);
 
-  /// \brief Default destructor
   ~LandmarkNoiseEvaluator()=default;
   
   /// \brief Evaluates the reprojection covariance 

--- a/include/steam/problem/loss_func/dcs_loss_func.hpp
+++ b/include/steam/problem/loss_func/dcs_loss_func.hpp
@@ -8,7 +8,7 @@
 
 namespace steam {
 
-/** \brief Huber loss function class */
+/** \brief Cauchy-Schwarz Divergence loss function class */
 class DcsLossFunc : public BaseLossFunc {
  public:
   /** \brief Convenience typedefs */

--- a/include/steam/problem/noise_model/base_noise_model.hpp
+++ b/include/steam/problem/noise_model/base_noise_model.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <Eigen/Dense>
-#include <iostream>
 
 namespace steam {
 

--- a/include/steam/problem/noise_model/base_noise_model.hpp
+++ b/include/steam/problem/noise_model/base_noise_model.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include <iostream>
 
 namespace steam {
 
@@ -38,3 +39,4 @@ class BaseNoiseModel {
 };
 
 }  // namespace steam
+

--- a/include/steam/problem/noise_model/base_noise_model.hpp
+++ b/include/steam/problem/noise_model/base_noise_model.hpp
@@ -8,6 +8,9 @@
 
 namespace steam {
 
+/** \brief Enumeration of ways to set the noise */
+enum class NoiseType { COVARIANCE, INFORMATION, SQRT_INFORMATION };
+
 /** \brief BaseNoiseModel Base class for the steam noise models */
 template <int DIM>
 class BaseNoiseModel {

--- a/include/steam/problem/noise_model/dynamic_noise_model.hpp
+++ b/include/steam/problem/noise_model/dynamic_noise_model.hpp
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <iostream>
+
 #include "steam/problem/noise_model/base_noise_model.hpp"
 #include "steam/evaluable/evaluable.hpp"
 
@@ -26,7 +28,7 @@ class DynamicNoiseModel : public BaseNoiseModel<DIM> {
   using MatrixTEvalPtr = typename Evaluable<MatrixT>::ConstPtr;
 
   static Ptr MakeShared(const MatrixTEvalPtr& eval,
-                        const NoiseType& type = NoiseType::COVARIANCE);
+                        const NoiseType type = NoiseType::COVARIANCE);
 
   /**
    * \brief Constructor
@@ -34,7 +36,7 @@ class DynamicNoiseModel : public BaseNoiseModel<DIM> {
    * \param[in] type The type of noise matrix set in the previous paramter.
    */
   DynamicNoiseModel(const MatrixTEvalPtr& eval,
-                   const NoiseType& type = NoiseType::COVARIANCE);
+                   const NoiseType type = NoiseType::COVARIANCE);
 
   /** \brief Get a reference to the square root information matrix */
   MatrixT getSqrtInformation() const override;
@@ -65,18 +67,35 @@ class DynamicNoiseModel : public BaseNoiseModel<DIM> {
    * triangular matrix is stored directly for faster error whitening.
    */
   const MatrixTEvalPtr& eval_;
-  const NoiseType& type_;
+  NoiseType type_;
 };
+
+// std::ostream& operator<< (std::ostream& in, const steam::NoiseType& noise){
+//   switch (noise)
+//   {
+//   case steam::NoiseType::COVARIANCE:
+//     return in << "COVARIANCE";
+//   case steam::NoiseType::INFORMATION:
+//     return in << "INFORMATION";
+//   case steam::NoiseType::SQRT_INFORMATION:
+//     return in << "SQRT_INFORMATION";
+//   default:
+//     return in << "Unknown type for NoiseType";
+//   }
+// }
 
 template <int DIM>
 auto DynamicNoiseModel<DIM>::MakeShared(const MatrixTEvalPtr& eval,
-                                       const NoiseType& type) -> Ptr {
+                                       const NoiseType type) -> Ptr {
+  std::cout << "The noise type is " << static_cast<int>(type);
   return std::make_shared<DynamicNoiseModel<DIM>>(eval, type);
 }
 
 template <int DIM>
 DynamicNoiseModel<DIM>::DynamicNoiseModel(const MatrixTEvalPtr& eval,
-                                        const NoiseType& type) : eval_(eval), type_(type) {}
+                                        const NoiseType type) : eval_(eval) {
+                                          type_ = type;
+                                        }
 
 template <int DIM>
 auto DynamicNoiseModel<DIM>::setByCovariance(const MatrixT& matrix) const -> MatrixT {

--- a/include/steam/problem/noise_model/dynamic_noise_model.hpp
+++ b/include/steam/problem/noise_model/dynamic_noise_model.hpp
@@ -27,7 +27,7 @@ class DynamicNoiseModel : public BaseNoiseModel<DIM> {
   using VectorT = Eigen::Matrix<double, DIM, 1>;
   using MatrixTEvalPtr = typename Evaluable<MatrixT>::ConstPtr;
 
-  static Ptr MakeShared(const MatrixTEvalPtr& eval,
+  static Ptr MakeShared(const MatrixTEvalPtr eval,
                         const NoiseType type = NoiseType::COVARIANCE);
 
   /**
@@ -35,7 +35,7 @@ class DynamicNoiseModel : public BaseNoiseModel<DIM> {
    * \param[in] Evaluable<matrix> A noise matrix evaluable, determined by the type parameter.
    * \param[in] type The type of noise matrix set in the previous paramter.
    */
-  DynamicNoiseModel(const MatrixTEvalPtr& eval,
+  DynamicNoiseModel(const MatrixTEvalPtr eval,
                    const NoiseType type = NoiseType::COVARIANCE);
 
   /** \brief Get a reference to the square root information matrix */
@@ -66,7 +66,7 @@ class DynamicNoiseModel : public BaseNoiseModel<DIM> {
    * decomposition on the information matrix (inverse covariance matrix). This
    * triangular matrix is stored directly for faster error whitening.
    */
-  const MatrixTEvalPtr& eval_;
+  const MatrixTEvalPtr eval_;
   NoiseType type_;
 };
 
@@ -85,16 +85,18 @@ class DynamicNoiseModel : public BaseNoiseModel<DIM> {
 // }
 
 template <int DIM>
-auto DynamicNoiseModel<DIM>::MakeShared(const MatrixTEvalPtr& eval,
+auto DynamicNoiseModel<DIM>::MakeShared(const MatrixTEvalPtr eval,
                                        const NoiseType type) -> Ptr {
   std::cout << "The noise type is " << static_cast<int>(type);
   return std::make_shared<DynamicNoiseModel<DIM>>(eval, type);
 }
 
 template <int DIM>
-DynamicNoiseModel<DIM>::DynamicNoiseModel(const MatrixTEvalPtr& eval,
+DynamicNoiseModel<DIM>::DynamicNoiseModel(const MatrixTEvalPtr eval,
                                         const NoiseType type) : eval_(eval) {
                                           type_ = type;
+                                          if (eval_ == nullptr)
+                                            std::cout << "Evaluator initialization failed somehow";
                                         }
 
 template <int DIM>
@@ -156,7 +158,7 @@ void DynamicNoiseModel<DIM>::assertPositiveDefiniteMatrix(
     std::stringstream ss;
     ss << "Covariance \n"
        << matrix << "\n must be positive definite. "
-       << "Min. eigenvalue : " << eigsolver.eigenvalues().minCoeff();
+       << "Min. eigenvalue : " << eigsolver.eigenvalues().minCoeff() << std::endl;
     throw std::invalid_argument(ss.str());
   }
 }

--- a/include/steam/problem/noise_model/dynamic_noise_model.hpp
+++ b/include/steam/problem/noise_model/dynamic_noise_model.hpp
@@ -1,6 +1,6 @@
 /**
- * \file StaticNoiseModel.hpp
- * \author Sean Anderson, ASRL
+ * \file DynamicNoiseModel.hpp
+ * \author Sean Anderson, Alec Krawciw ASRL
  */
 #pragma once
 
@@ -11,7 +11,7 @@ namespace steam {
 
 
 /**
- * \brief StaticNoiseModel Noise model for uncertainties that do not change
+ * \brief DynamicNoiseModel Noise model for uncertainties that change with the state variables
  * during the steam optimization problem.
  */
 template <int DIM>

--- a/include/steam/problem/noise_model/dynamic_noise_model.hpp
+++ b/include/steam/problem/noise_model/dynamic_noise_model.hpp
@@ -70,24 +70,11 @@ class DynamicNoiseModel : public BaseNoiseModel<DIM> {
   NoiseType type_;
 };
 
-// std::ostream& operator<< (std::ostream& in, const steam::NoiseType& noise){
-//   switch (noise)
-//   {
-//   case steam::NoiseType::COVARIANCE:
-//     return in << "COVARIANCE";
-//   case steam::NoiseType::INFORMATION:
-//     return in << "INFORMATION";
-//   case steam::NoiseType::SQRT_INFORMATION:
-//     return in << "SQRT_INFORMATION";
-//   default:
-//     return in << "Unknown type for NoiseType";
-//   }
-// }
+
 
 template <int DIM>
 auto DynamicNoiseModel<DIM>::MakeShared(const MatrixTEvalPtr eval,
                                        const NoiseType type) -> Ptr {
-  std::cout << "The noise type is " << static_cast<int>(type);
   return std::make_shared<DynamicNoiseModel<DIM>>(eval, type);
 }
 

--- a/src/evaluable/stereo/stereo_error_evaluator.cpp
+++ b/src/evaluable/stereo/stereo_error_evaluator.cpp
@@ -144,6 +144,8 @@ Eigen::Matrix<double,4,4> LandmarkNoiseEvaluator::value() const {
   }
   // evaluate the steam transform evaluator
   const lgmath::se3::Transformation T_l_p = T_query_map_->evaluate();
+  
+  std::cout << "T_l_p" << T_l_p;
 
   // Compute the new landmark noise
   Eigen::Matrix<double,4,4> lm_noise_l = T_l_p.matrix() * dialated_phi_ * T_l_p.matrix().transpose();
@@ -156,6 +158,9 @@ Eigen::Matrix<double,4,4> LandmarkNoiseEvaluator::value() const {
   if(positiveDefinite<3>(lm_noise_l_3)) {
     // compute the camera model jacobian based on the transformed mean.
     Eigen::Matrix4d camera_jacobian_j_ = stereo::cameraModelJacobian(intrinsics_, T_l_p*mean_);
+
+    std::cout << "Mean" << mean_ << "Cam jac" << camera_jacobian_j_;
+
 
     Eigen::Matrix<double,4,4> lm_noise = camera_jacobian_j_ * lm_noise_l * camera_jacobian_j_.transpose();
     Eigen::Matrix<double,3,3> lm_noise_3 = dialation_matrix.transpose() * lm_noise * dialation_matrix;
@@ -171,7 +176,7 @@ Eigen::Matrix<double,4,4> LandmarkNoiseEvaluator::value() const {
   }
 
   if (!positiveDefinite<4>(last_computed_cov_)) {
-    std::cout << "sum of noise is bad...";
+    std::cout << "sum of noise is bad..." << std::endl;
   }
   return last_computed_cov_;
 }

--- a/src/evaluable/stereo/stereo_error_evaluator.cpp
+++ b/src/evaluable/stereo/stereo_error_evaluator.cpp
@@ -71,6 +71,8 @@ Eigen::Vector4d cameraModel(
   return projectedMeas;
 }
 
+
+
 Eigen::Matrix4d cameraModelJacobian(
     const CameraIntrinsics::ConstPtr& intrinsics, const Eigen::Vector4d& point) {
   // Precompute values
@@ -134,8 +136,6 @@ void LandmarkNoiseEvaluator::getRelatedVarKeys(KeySet& keys) const {}
 /// @brief evaluatecovariance
 //////////////////////////////////////////////////////////////////////////////////////////////
 Eigen::Matrix<double,4,4> LandmarkNoiseEvaluator::value() const {
-  // TODO: Check to see if we need to recaulculate (add a change flag to steam variables.)
-
   // Add the measurement noise.
   Eigen::Matrix4d last_computed_cov_ = meas_noise_;
 
@@ -145,7 +145,6 @@ Eigen::Matrix<double,4,4> LandmarkNoiseEvaluator::value() const {
   // evaluate the steam transform evaluator
   const lgmath::se3::Transformation T_l_p = T_query_map_->evaluate();
   
-  std::cout << "T_l_p" << T_l_p;
 
   // Compute the new landmark noise
   Eigen::Matrix<double,4,4> lm_noise_l = T_l_p.matrix() * dialated_phi_ * T_l_p.matrix().transpose();
@@ -159,7 +158,6 @@ Eigen::Matrix<double,4,4> LandmarkNoiseEvaluator::value() const {
     // compute the camera model jacobian based on the transformed mean.
     Eigen::Matrix4d camera_jacobian_j_ = stereo::cameraModelJacobian(intrinsics_, T_l_p*mean_);
 
-    std::cout << "Mean" << mean_ << "Cam jac" << camera_jacobian_j_;
 
 
     Eigen::Matrix<double,4,4> lm_noise = camera_jacobian_j_ * lm_noise_l * camera_jacobian_j_.transpose();

--- a/src/evaluable/stereo/stereo_error_evaluator.cpp
+++ b/src/evaluable/stereo/stereo_error_evaluator.cpp
@@ -26,13 +26,13 @@ void StereoErrorEvaluator::getRelatedVarKeys(KeySet& keys) const {
 }
 
 auto StereoErrorEvaluator::value() const -> OutType {
-  return meas_ - cameraModel(eval_->value());
+  return meas_ - cameraModel(intrinsics_, eval_->value());
 }
 
 auto StereoErrorEvaluator::forward() const -> Node<OutType>::Ptr {
   // error between measurement and point estimate projected in camera frame
   const auto child = eval_->forward();
-  const auto value = meas_ - cameraModel(child->value());
+  const auto value = meas_ - cameraModel(intrinsics_, child->value());
   const auto node = Node<OutType>::MakeShared(value);
   node->addChild(child);
   return node;
@@ -44,55 +44,124 @@ void StereoErrorEvaluator::backward(const Eigen::MatrixXd& lhs,
   if (eval_->active()) {
     const auto child = std::static_pointer_cast<Node<LmInType>>(node->at(0));
     // Get Jacobians
-    Eigen::Matrix4d new_lhs = (-1) * lhs * cameraModelJacobian(child->value());
+    Eigen::Matrix4d new_lhs = (-1) * lhs * cameraModelJacobian(intrinsics_, child->value());
 
     eval_->backward(new_lhs, child, jacs);
   }
 }
 
-Eigen::Vector4d StereoErrorEvaluator::cameraModel(
-    const Eigen::Vector4d& point) const {
+Eigen::Vector4d cameraModel(
+    const CameraIntrinsics::ConstPtr& intrinsics, const Eigen::Vector4d& point) {
   // Precompute values
   const double x = point[0];
   const double y = point[1];
   const double z = point[2];
   const double w = point[3];
-  const double xr = x - w * intrinsics_->b;
+  const double xr = x - w * intrinsics->b;
   const double one_over_z = 1.0 / z;
 
   // Project point into camera coordinates
   Eigen::Vector4d projectedMeas;
   // clang-format off
-  projectedMeas << intrinsics_->fu * x * one_over_z + intrinsics_->cu,
-                   intrinsics_->fv * y * one_over_z + intrinsics_->cv,
-                   intrinsics_->fu * xr * one_over_z + intrinsics_->cu,
-                   intrinsics_->fv * y * one_over_z + intrinsics_->cv;
+  projectedMeas << intrinsics->fu * x * one_over_z + intrinsics->cu,
+                   intrinsics->fv * y * one_over_z + intrinsics->cv,
+                   intrinsics->fu * xr * one_over_z + intrinsics->cu,
+                   intrinsics->fv * y * one_over_z + intrinsics->cv;
   // clang-format on
   return projectedMeas;
 }
 
-Eigen::Matrix4d StereoErrorEvaluator::cameraModelJacobian(
-    const Eigen::Vector4d& point) const {
+Eigen::Matrix4d cameraModelJacobian(
+    const CameraIntrinsics::ConstPtr& intrinsics, const Eigen::Vector4d& point) {
   // Precompute values
   const double x = point[0];
   const double y = point[1];
   const double z = point[2];
   const double w = point[3];
-  const double xr = x - w * intrinsics_->b;
+  const double xr = x - w * intrinsics->b;
   const double one_over_z = 1.0 / z;
   const double one_over_z2 = one_over_z * one_over_z;
 
   // Construct Jacobian with respect to x, y, z, and scalar w
-  const double dw = -intrinsics_->fu * intrinsics_->b * one_over_z;
+  const double dw = -intrinsics->fu * intrinsics->b * one_over_z;
   Eigen::Matrix4d jac;
   // clang-format off
-  jac << intrinsics_->fu * one_over_z, 0.0, -intrinsics_->fu * x * one_over_z2, 0.0,
-         0.0, intrinsics_->fv * one_over_z, -intrinsics_->fv * y * one_over_z2, 0.0,
-         intrinsics_->fu * one_over_z, 0.0, -intrinsics_->fu * xr * one_over_z2, dw,
-         0.0, intrinsics_->fv * one_over_z, -intrinsics_->fv * y * one_over_z2, 0.0;
+  jac << intrinsics->fu * one_over_z, 0.0, -intrinsics->fu * x * one_over_z2, 0.0,
+         0.0, intrinsics->fv * one_over_z, -intrinsics->fv * y * one_over_z2, 0.0,
+         intrinsics->fu * one_over_z, 0.0, -intrinsics->fu * xr * one_over_z2, dw,
+         0.0, intrinsics->fv * one_over_z, -intrinsics->fv * y * one_over_z2, 0.0;
   // clang-format on
   return jac;
 }
+
+
+LandmarkNoiseEvaluator::LandmarkNoiseEvaluator(const Eigen::Vector4d& landmark_mean,
+                             const Eigen::Matrix3d& landmark_cov,
+                             const Eigen::Matrix4d& meas_noise,
+                             const CameraIntrinsics::ConstPtr& intrinsics,
+                             const se3::SE3StateVar::ConstPtr& T_query_map) : 
+intrinsics_(intrinsics),
+meas_noise_(meas_noise),
+mean_(landmark_mean),
+T_query_map_(T_query_map) {
+  // compute the dialated phi;
+  dialated_phi_.setZero();
+  dialated_phi_.block(0,0,3,3) = landmark_cov;
+  if(!positiveDefinite<3>(landmark_cov)) {
+    std::cout <<  "\nmigrated cov is bad!!!\n";
+  }
+}
+
+// bool LandmarkNoiseEvaluator::active() {
+//   return true;
+// }
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+/// @brief evaluatecovariance
+//////////////////////////////////////////////////////////////////////////////////////////////
+Eigen::Matrix<double,4,4> LandmarkNoiseEvaluator::value() {
+  // TODO: Check to see if we need to recaulculate (add a change flag to steam variables.)
+
+  // Add the measurement noise.
+  last_computed_cov_ = meas_noise_;
+
+  if(!positiveDefinite<4>(meas_noise_)) {
+    std::cout << "measurement noise is bad!!";
+  }
+  // evaluate the steam transform evaluator
+  const lgmath::se3::Transformation T_l_p = T_query_map_->evaluate();
+
+  // Compute the new landmark noise
+  Eigen::Matrix<double,4,4> lm_noise_l = T_l_p.matrix() * dialated_phi_ * T_l_p.matrix().transpose();
+
+  Eigen::Matrix<double,4,3> dialation_matrix;
+  dialation_matrix.setZero();
+  dialation_matrix.block(0,0,3,3) = Eigen::Matrix<double,3,3>::Identity();
+  Eigen::Matrix<double,3,3> lm_noise_l_3 = dialation_matrix.transpose() * lm_noise_l * dialation_matrix;
+
+  if(positiveDefinite<3>(lm_noise_l_3)) {
+    // compute the camera model jacobian based on the transformed mean.
+    camera_jacobian_j_ = stereo::cameraModelJacobian(intrinsics_, T_l_p*mean_);
+
+    Eigen::Matrix<double,4,4> lm_noise = camera_jacobian_j_ * lm_noise_l * camera_jacobian_j_.transpose();
+    Eigen::Matrix<double,3,3> lm_noise_3 = dialation_matrix.transpose() * lm_noise * dialation_matrix;
+
+    if(positiveDefinite<3>(lm_noise_3)) {
+      last_computed_cov_ += lm_noise;
+    } else {
+      std::cout << "\nmigrated noise is not positive definite!!\n";
+    }
+    // return the new noise.
+  } else {
+    std::cout << "\nlm_noise_l is bad!!\n";
+  }
+
+  if (!positiveDefinite<4>(last_computed_cov_)) {
+    std::cout << "sum of noise is bad...";
+  }
+  return last_computed_cov_;
+}
+
 
 }  // end namespace stereo
 }  // namespace steam

--- a/src/evaluable/stereo/stereo_error_evaluator.cpp
+++ b/src/evaluable/stereo/stereo_error_evaluator.cpp
@@ -132,9 +132,6 @@ void LandmarkNoiseEvaluator::backward(const Eigen::MatrixXd& lhs,
 void LandmarkNoiseEvaluator::getRelatedVarKeys(KeySet& keys) const {}
 
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-/// @brief evaluatecovariance
-//////////////////////////////////////////////////////////////////////////////////////////////
 Eigen::Matrix<double,4,4> LandmarkNoiseEvaluator::value() const {
   // Add the measurement noise.
   Eigen::Matrix4d last_computed_cov_ = meas_noise_;
@@ -157,8 +154,6 @@ Eigen::Matrix<double,4,4> LandmarkNoiseEvaluator::value() const {
   if(positiveDefinite<3>(lm_noise_l_3)) {
     // compute the camera model jacobian based on the transformed mean.
     Eigen::Matrix4d camera_jacobian_j_ = stereo::cameraModelJacobian(intrinsics_, T_l_p*mean_);
-
-
 
     Eigen::Matrix<double,4,4> lm_noise = camera_jacobian_j_ * lm_noise_l * camera_jacobian_j_.transpose();
     Eigen::Matrix<double,3,3> lm_noise_3 = dialation_matrix.transpose() * lm_noise * dialation_matrix;


### PR DESCRIPTION
Add support for noise models that change based on the value of state variables.

Additionally, add a noise model for the projected and linearized covariance of landmarks into pixels for stereo cameras. 